### PR TITLE
bugfix | fix two loaders appearing when article list is initialized

### DIFF
--- a/src/components/ArticlesList.tsx
+++ b/src/components/ArticlesList.tsx
@@ -71,52 +71,43 @@ export const ArticlesList: React.FC<ArticlesListProps> = ({
     [createArticleHandlers, styles.articleCard]
   );
 
-  const renderLoadingFooter = useCallback(() => {
+  const renderFooter = useCallback(() => {
+    if (!isLoading) return null;
     return (
       <View style={styles.loadingFooter}>
         <ActivityIndicator size='small' color={COLORS.PRIMARY} />
       </View>
     );
-  }, [styles.loadingFooter]);
-
-  const renderFooter = useCallback(() => {
-    if (!isLoading) return null;
-    return renderLoadingFooter();
-  }, [isLoading, renderLoadingFooter]);
-
-  const renderLoadingIndicator = useCallback(() => {
-    return (
-      <View style={styles.centerContainer}>
-        <ActivityIndicator size='large' color={COLORS.PRIMARY} />
-      </View>
-    );
-  }, [styles.centerContainer]);
-
-  const renderEmptyMessage = useCallback(() => {
-    return (
-      <View style={styles.centerContainer}>
-        <Text style={styles.emptyText}>{emptyMessage}</Text>
-      </View>
-    );
-  }, [styles.centerContainer, styles.emptyText, emptyMessage]);
+  }, [isLoading, styles.loadingFooter]);
 
   const renderEmpty = useCallback(() => {
-    if (articles.length === 0 && isLoading) {
-      return renderLoadingIndicator();
+    if (articles.length === 0 && !isLoading) {
+      return (
+        <View style={styles.centerContainer}>
+          <Text style={styles.emptyText}>{emptyMessage}</Text>
+        </View>
+      );
     }
-    return renderEmptyMessage();
-  }, [articles.length, isLoading, renderEmptyMessage, renderLoadingIndicator]);
+    return null;
+  }, [
+    articles.length,
+    isLoading,
+    emptyMessage,
+    styles.centerContainer,
+    styles.emptyText,
+  ]);
 
-  const createRefreshControl = useCallback(() => {
-    return (
+  const refreshControl = useMemo(
+    () => (
       <RefreshControl
-        refreshing={isLoading && articles.length === 0}
+        refreshing={isLoading}
         onRefresh={onRefresh}
         colors={[COLORS.PRIMARY]}
         tintColor={COLORS.PRIMARY}
       />
-    );
-  }, [isLoading, articles.length, onRefresh]);
+    ),
+    [isLoading, onRefresh]
+  );
 
   return (
     <View style={containerStyle}>
@@ -124,7 +115,7 @@ export const ArticlesList: React.FC<ArticlesListProps> = ({
         data={articles}
         renderItem={renderArticle}
         keyExtractor={item => `${contextKey}-${item.slug}`}
-        refreshControl={createRefreshControl()}
+        refreshControl={refreshControl}
         onEndReached={onLoadMore}
         onEndReachedThreshold={0.1}
         ListFooterComponent={renderFooter}

--- a/src/screens/homeScreen/homeScreen.tsx
+++ b/src/screens/homeScreen/homeScreen.tsx
@@ -42,25 +42,22 @@ export const HomeScreen: NavioScreen = observer(() => {
   return (
     <View style={styles.container} testID={TEST_IDS.HOME_SCREEN}>
       <ScreenHeader />
+      {renderFeedTabs()}
 
-      <View flex backgroundColor={COLORS.BACKGROUND}>
-        {renderFeedTabs()}
-
-        <ArticlesList
-          articles={articles}
-          isLoading={isLoading}
-          onRefresh={refreshArticles}
-          onLoadMore={loadMoreArticles}
-          onArticlePress={handleArticlePress}
-          onFavoritePress={handleFavoritePress}
-          emptyMessage={
-            feedType === FEED_TYPES.FEED
-              ? 'Follow some users to see their articles here'
-              : 'No articles available'
-          }
-          contextKey='home'
-        />
-      </View>
+      <ArticlesList
+        articles={articles}
+        isLoading={isLoading}
+        onRefresh={refreshArticles}
+        onLoadMore={loadMoreArticles}
+        onArticlePress={handleArticlePress}
+        onFavoritePress={handleFavoritePress}
+        emptyMessage={
+          feedType === FEED_TYPES.FEED
+            ? 'Follow some users to see their articles here'
+            : 'No articles available'
+        }
+        contextKey='home'
+      />
     </View>
   );
 });


### PR DESCRIPTION
This pull request refactors the `ArticlesList` component and simplifies the `HomeScreen` layout by removing unnecessary wrappers and improving readability. The changes focus on optimizing the code structure and improving maintainability.

### Refactoring in `ArticlesList` component (`src/components/ArticlesList.tsx`):

* Removed the `renderLoadingFooter` and `renderLoadingIndicator` methods, consolidating them into the `renderFooter` method for simplicity.
* Updated the `renderEmpty` method to directly handle the empty state and removed the dependency on a separate `renderEmptyMessage` method.
* Replaced the `createRefreshControl` function with a `useMemo`-based `refreshControl` for better performance and readability.

### Simplification in `HomeScreen` layout (`src/screens/homeScreen/homeScreen.tsx`):

* Removed an unnecessary `View` wrapper around the `ArticlesList` component, reducing nesting and improving layout clarity. [[1]](diffhunk://#diff-39c588f2beb2ad86a17bea727f8fdfecf27198e07b1c43c2237e841f0babedf1L45-L46) [[2]](diffhunk://#diff-39c588f2beb2ad86a17bea727f8fdfecf27198e07b1c43c2237e841f0babedf1L64)