### PR TITLE
bugfix | disable error alert when getting 401 responses

### DIFF
--- a/src/services/common/BaseService.ts
+++ b/src/services/common/BaseService.ts
@@ -36,6 +36,12 @@ export abstract class BaseService {
 
   protected _logError(errorResponse: ApiErrorResponse): never {
     this._logApiError(errorResponse);
+
+    throw errorResponse;
+  }
+
+  protected _logErrorAndShowAlert(errorResponse: ApiErrorResponse): never {
+    this._logApiError(errorResponse);
     this._showErrorAlert(errorResponse);
     throw errorResponse;
   }


### PR DESCRIPTION
This pull request introduces a new method to the `BaseService` class in `src/services/common/BaseService.ts`. The addition enhances error handling by providing an option to log errors and display an alert before throwing the error.

Error handling improvements:

* [`src/services/common/BaseService.ts`](diffhunk://#diff-e5208819e8cf3a3d38668b56cb974982b0f23c2351fd89e021aa593fb26cb15bR39-R44): Added the `_logErrorAndShowAlert` method, which logs an API error, displays an error alert, and then throws the error. This complements the existing `_logError` method by incorporating user-facing error alerts.