### PR TITLE
bugfix | fix app not navigating to mainTabs even when there is a saved user

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import * as SplashScreen from 'expo-splash-screen';
@@ -9,6 +9,7 @@ import { observer } from 'mobx-react';
 import './src/locales';
 import { COLORS } from './src/constants/styles';
 import { navio } from './src/navigation/navio';
+import { navigationService } from './src/services';
 import { userStore } from './src/store/userStore';
 import { useAppTheme } from './src/theme';
 
@@ -18,6 +19,7 @@ const AppWrapper = observer(() => {
   const isThemeReady = useAppTheme();
   const isUserStoreInitialized = userStore.isInitialized;
   const isAuthenticated = userStore.isAuthenticated();
+  const navigationHandledRef = useRef(false);
 
   const isAppReady = useMemo(
     () => isThemeReady && isUserStoreInitialized,
@@ -25,14 +27,20 @@ const AppWrapper = observer(() => {
   );
 
   useEffect(() => {
-    if (isAppReady) {
-      if (isAuthenticated) {
-        navio.setRoot('tabs', 'MainTabs');
-      } else {
-        navio.setRoot('tabs', 'AuthTabs');
-      }
+    if (isAppReady && !navigationHandledRef.current) {
+      const handleNavigation = () => {
+        navigationHandledRef.current = true;
 
-      SplashScreen.hideAsync();
+        if (isAuthenticated) {
+          navigationService.navigateToMainTabs();
+        } else {
+          navigationService.navigateToAuthTabs();
+        }
+
+        SplashScreen.hideAsync();
+      };
+
+      requestAnimationFrame(handleNavigation);
     }
   }, [isAppReady, isAuthenticated]);
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ module.exports = [
         __filename: 'readonly',
         module: 'readonly',
         exports: 'readonly',
+        requestAnimationFrame: 'readonly',
       },
     },
     plugins: {


### PR DESCRIPTION
This pull request introduces changes to improve navigation handling in the `App.tsx` file and updates the ESLint configuration to support the new functionality. The most important changes include adding a `useRef` hook to track navigation state, replacing direct `navio` calls with `navigationService` methods, and ensuring `requestAnimationFrame` is properly recognized in the ESLint configuration.

### Navigation handling improvements:

* [`App.tsx`](diffhunk://#diff-a369d17a5dcc6a08663afe8ec644ed0ebc2624f39b704924078c01fd52c58fa3R22-R43): Added a `useRef` hook (`navigationHandledRef`) to prevent redundant navigation logic execution. Updated the `useEffect` to use `requestAnimationFrame` for smoother navigation handling and replaced `navio.setRoot` calls with `navigationService.navigateToMainTabs` and `navigationService.navigateToAuthTabs` for better abstraction.

### ESLint configuration update:

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839R90): Added `requestAnimationFrame` to the list of global variables marked as `readonly` to support its usage in the updated navigation logic.